### PR TITLE
StateSnapshot should be closed to further action dispatch, commit, or discard after it has generated it's successor snapshot

### DIFF
--- a/lib/state-snapshot.js
+++ b/lib/state-snapshot.js
@@ -4,9 +4,15 @@ class StateSnapshot {
     this.initialState = { ...initialState };
     this.items = { ...currentState };
     this.meta = meta;
+    this.closed = false;
   }
 
   async dispatchToStateSnapshot(action) {
+    if (this.closed) {
+      throw new Error('Attempted to dispatch action to closed StateSnapshot');
+    }
+
+    this.closed = true;
     const newItems = await this.store.reducer({ ...this.items }, action);
 
     return new StateSnapshot({
@@ -18,6 +24,11 @@ class StateSnapshot {
   }
 
   async commitStateSnapshot() {
+    if (this.closed) {
+      throw new Error('Attempted to dispatch action to closed StateSnapshot');
+    }
+
+    this.closed = true;
     await this.store.commit({
       meta: this.meta,
       items: this.items,
@@ -31,6 +42,11 @@ class StateSnapshot {
   }
 
   async discardStateSnapshot() {
+    if (this.closed) {
+      throw new Error('Attempted to dispatch action to closed StateSnapshot');
+    }
+
+    this.closed = true;
     await this.store.discard({
       meta: this.meta,
       items: this.items,

--- a/test/action-dispatch/dispatchToStateSnapshot.js
+++ b/test/action-dispatch/dispatchToStateSnapshot.js
@@ -62,4 +62,47 @@ describe('stateSnapshot.dispatchToStateSnapshot()', () => {
 
     oldSnapshot.items.should.deepEqual({ itemType: [{ test: 'item' }] });
   });
+
+  it('should set the closed property on the existing state snapshot', async () => {
+    const mockBackingStore = {
+      selectItems: () => ({
+        results: { itemType: [{ test: 'item' }] },
+        meta: {},
+      }),
+    };
+    const store = cloverleaf.createStore(mockBackingStore);
+    const fakeReducer = (state, action) => action;
+    store.registerReducer(cloverleaf.createReducer(fakeReducer));
+    const oldSnapshot = await store.getStateSnapshotBySelector({
+      test: 'selector',
+    });
+    await oldSnapshot.dispatchToStateSnapshot({
+      reducer: 'reduced',
+    });
+
+    oldSnapshot.should.have.property('closed');
+    oldSnapshot.closed.should.equal(true);
+  });
+
+  it('should reject if the state snapshot is closed', async () => {
+    const mockBackingStore = {
+      selectItems: () => ({
+        results: { itemType: [{ test: 'item' }] },
+        meta: {},
+      }),
+    };
+    const store = cloverleaf.createStore(mockBackingStore);
+    const fakeReducer = (state, action) => action;
+    store.registerReducer(cloverleaf.createReducer(fakeReducer));
+    const oldSnapshot = await store.getStateSnapshotBySelector({
+      test: 'selector',
+    });
+    oldSnapshot.closed = true;
+
+    return oldSnapshot
+      .dispatchToStateSnapshot({
+        reducer: 'reduced',
+      })
+      .should.be.rejected();
+  });
 });

--- a/test/state-snapshot/commitStateSnapshot.js
+++ b/test/state-snapshot/commitStateSnapshot.js
@@ -68,6 +68,43 @@ describe('stateSnapshot.commitStateSnapshot', () => {
 
       committedSnapshot.items.should.deepEqual(reducedSnapshot.items);
     });
+
+    it('should set the closed property on the original state snapshot', async () => {
+      const mockBackingStore = {
+        commitChanges() {},
+        selectItems: () => ({
+          results: { itemType: [{ test: 'item' }] },
+          meta: {},
+        }),
+      };
+      const store = cloverleaf.createStore(mockBackingStore);
+      const fakeReducer = (state, action) => action;
+      store.registerReducer(cloverleaf.createReducer(fakeReducer));
+      const originalSnapshot = await store.getStateSnapshotBySelector({
+        test: 'selector',
+      });
+      await originalSnapshot.commitStateSnapshot();
+
+      originalSnapshot.should.have.property('closed');
+      originalSnapshot.closed.should.equal(true);
+    });
+  });
+
+  it('should reject if the state snapshot is closed', async () => {
+    const mockBackingStore = {
+      commitChanges() {},
+      selectItems: () => ({
+        results: { itemType: [{ test: 'item' }] },
+        meta: {},
+      }),
+    };
+    const store = cloverleaf.createStore(mockBackingStore);
+    const originalSnapshot = await store.getStateSnapshotBySelector({
+      test: 'selector',
+    });
+    originalSnapshot.closed = true;
+
+    return originalSnapshot.commitStateSnapshot().should.be.rejected();
   });
 
   context('backing store returns a promise that rejects', () => {


### PR DESCRIPTION
This prevents subtle bugs that might crop up from reusing stale state snapshots.

Fixes #3